### PR TITLE
Fix for breaking changes in typescript 2.6

### DIFF
--- a/lib/apisauce.d.ts
+++ b/lib/apisauce.d.ts
@@ -93,14 +93,16 @@ export interface ApisauceInstance {
   unlink: <T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T>>;
 }
 
-export default {
-  DEFAULT_HEADERS,
-  NONE,
-  CLIENT_ERROR,
-  SERVER_ERROR,
-  TIMEOUT_ERROR,
-  CONNECTION_ERROR,
-  NETWORK_ERROR,
-  UNKNOWN_ERROR,
-  create
+declare const _default: {
+  DEFAULT_HEADERS: typeof DEFAULT_HEADERS;
+  NONE: typeof NONE;
+  CLIENT_ERROR: typeof CLIENT_ERROR;
+  SERVER_ERROR: typeof SERVER_ERROR;
+  TIMEOUT_ERROR: typeof TIMEOUT_ERROR;
+  CONNECTION_ERROR: typeof CONNECTION_ERROR;
+  NETWORK_ERROR: typeof NETWORK_ERROR;
+  UNKNOWN_ERROR: typeof UNKNOWN_ERROR;
+  create: typeof create;
 }
+
+export default _default;

--- a/package.json
+++ b/package.json
@@ -62,5 +62,5 @@
     "parser": "babel-eslint"
   },
   "types": "./dist/apisauce.d.ts",
-  "version": "0.14.1"
+  "version": "0.14.2"
 }

--- a/package.json
+++ b/package.json
@@ -62,5 +62,5 @@
     "parser": "babel-eslint"
   },
   "types": "./dist/apisauce.d.ts",
-  "version": "0.14.2"
+  "version": "0.14.1"
 }


### PR DESCRIPTION
Fixes issue:
```
node_modules/apisauce/dist/apisauce.d.ts
(96,16): error TS2714: The expression of an export assignment must be an identifier or qualified name in an ambient context
```

Resulting in TypeScript 2.6 due to breaking changes introduced.
See: https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#arbitrary-expressions-are-forbidden-in-export-assignments-in-ambient-contexts