### PR TITLE
Export const two times

### DIFF
--- a/lib/apisauce.d.ts
+++ b/lib/apisauce.d.ts
@@ -92,15 +92,3 @@ export interface ApisauceInstance {
   link: <T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T>>;
   unlink: <T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T>>;
 }
-
-export default {
-  DEFAULT_HEADERS,
-  NONE,
-  CLIENT_ERROR,
-  SERVER_ERROR,
-  TIMEOUT_ERROR,
-  CONNECTION_ERROR,
-  NETWORK_ERROR,
-  UNKNOWN_ERROR,
-  create
-}


### PR DESCRIPTION
I don't know why you export  
```
  DEFAULT_HEADERS,
  NONE,
  CLIENT_ERROR,
  SERVER_ERROR,
  TIMEOUT_ERROR,
  CONNECTION_ERROR,
  NETWORK_ERROR,
  UNKNOWN_ERROR,
  create
```
with the export keyword in front of each constant and once at the end as export default.

It's useless from my point of view.