### PR TITLE
export ApiOkResponse & ApiErrorResponse

### DIFF
--- a/lib/apisauce.d.ts
+++ b/lib/apisauce.d.ts
@@ -33,7 +33,7 @@ export interface ApisauceConfig extends AxiosRequestConfig {
  */
 export function create(config: ApisauceConfig): ApisauceInstance;
 
-interface ApiErrorResponse<T> {
+export interface ApiErrorResponse<T> {
   ok: false;
   problem: PROBLEM_CODE;
 
@@ -43,7 +43,7 @@ interface ApiErrorResponse<T> {
   config?: AxiosRequestConfig;
   duration?: number;
 }
-interface ApiOkResponse<T> {
+export interface ApiOkResponse<T> {
   ok: true;
   problem: null;
 


### PR DESCRIPTION
I propose this change because in this case:
```
class MyApi {
   ....
   public async getPage (id: number) {
    const response = await this.api.get('page', { id }) as apisauce.ApiResponse<Root>

    if (!response.ok) {
      throw new Error(response.problem)
    }

    // response will be ApiOkResponse<Root> right ?
    return response
  }
}
```

You will get this error if declaration is set to true in your tsconfig.json:
`Exported method has or is using name 'ApiOkResponse' from external module 'a/file/path/apisauce' but cannot be named`.