### PR TITLE
baseURL is string or undefined

### DIFF
--- a/apisauce.d.ts
+++ b/apisauce.d.ts
@@ -24,7 +24,7 @@ export type PROBLEM_CODE =
   'CANCEL_ERROR';
 
 export interface ApisauceConfig extends AxiosRequestConfig {
-  baseURL: string;
+  baseURL: string | undefined;
 }
 
 /**


### PR DESCRIPTION
Allows `baseURL` to be `undefined`. This is needed to do something like this: 
```
baseURL: process.env.MY_ENVIRONMENT_VARIABLE
```