### PR TITLE
Use curryN for predicate functions

### DIFF
--- a/lib/apisauce.ts
+++ b/lib/apisauce.ts
@@ -7,6 +7,7 @@ import {
   is,
   T,
   curry,
+  curryN,
   gte,
   ifElse,
   prop,
@@ -55,7 +56,7 @@ const toNumber = cond([
  * isWithin(1, 5, 5) //=> true
  * isWithin(1, 5, 5.1) //=> false
  */
-const isWithin = curry((min, max, value) => {
+const isWithin = curryN(3, (min, max, value) => {
   const isNumber = is(Number)
   return (
     isNumber(min) &&
@@ -67,7 +68,7 @@ const isWithin = curry((min, max, value) => {
 })
 
 // a workaround to deal with __ not being available from the ramda types in typescript
-const containsText = textToSearch => list => contains(list, textToSearch)
+const containsText = curryN(2, (textToSearch, list) => contains(list, textToSearch))
 
 /**
  * Are we dealing with a promise?

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "rollup-plugin-filesize": "^1.5.0",
     "rollup-plugin-uglify": "^3.0.0",
     "standard": "^11.0.1",
-    "typescript": "2.8.3"
+    "typescript": "3.2.1"
   },
   "files": [
     "dist/apisauce.js",


### PR DESCRIPTION
Typescript was complaining about the types of the predicate functions being used in ramda cond calls. This was causing tests to fail. Using curryN allows the functions to remain the same, but typescript no longer complains. Tests are passing.

Original errors:

In `getProblemFromError`:

![image](https://user-images.githubusercontent.com/1761434/49411152-a689e500-f71c-11e8-98d8-a2960f430400.png)

In `getProblemFromStatus`:

![image](https://user-images.githubusercontent.com/1761434/49411158-b1447a00-f71c-11e8-901c-8579ba6464ef.png)

Tests:

![image](https://user-images.githubusercontent.com/1761434/49411275-21eb9680-f71d-11e8-9887-b2c5df4d394c.png)

