### PR TITLE
Bump npm-run-all dev dependency to safe version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "babel-plugin-ramda": "^1.6.1",
     "babel-preset-es2015": "^6.24.1",
     "np": "3.0.4",
-    "npm-run-all": "^4.1.3",
+    "npm-run-all": "^4.1.5",
     "nyc": "^11.8.0",
     "ramdasauce": "^2.1.0",
     "rollup": "^0.59.1",


### PR DESCRIPTION
This bumps the `npm-run-all` dependency to 4.1.5 to avoid the malicious dependency issue with `flatmap-stream`. 

https://github.com/mysticatea/npm-run-all/issues/153

Since this is a dev dependency, there should be any risk to the package. 