### PR TITLE
Upgrade axios to address CVE-2019-10742

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     ]
   },
   "dependencies": {
-    "axios": "^0.19.0",
+    "axios": "^0.18.1",
     "ramda": "^0.25.0"
   },
   "description": "Axios + standardized errors + request/response transforms.",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     ]
   },
   "dependencies": {
-    "axios": "^0.18.0",
+    "axios": "^0.19.0",
     "ramda": "^0.25.0"
   },
   "description": "Axios + standardized errors + request/response transforms.",


### PR DESCRIPTION
See https://github.com/axios/axios/pull/1485 which was shipped with v0.19.0

CVE - https://nvd.nist.gov/vuln/detail/CVE-2019-10742