### PR TITLE
Add the ability to pass the already created axios instance in the config

### DIFF
--- a/apisauce.d.ts
+++ b/apisauce.d.ts
@@ -25,6 +25,7 @@ export type PROBLEM_CODE =
 
 export interface ApisauceConfig extends AxiosRequestConfig {
   baseURL: string | undefined;
+  axiosInstance: AxiosInstance | undefined;
 }
 
 /**

--- a/lib/apisauce.ts
+++ b/lib/apisauce.ts
@@ -127,13 +127,19 @@ export const getProblemFromStatus = status => {
  * Creates a instance of our API using the configuration.
  */
 export const create = config => {
-  // combine the user's defaults with ours
+  // combine the user's headers with ours
   const headers = merge(DEFAULT_HEADERS, config.headers || {})
-  const combinedConfig = merge(DEFAULT_CONFIG, dissoc('headers', config))
 
-  // create the axios instance
-  const instance = axios.create(combinedConfig)
-
+  let instance
+  if (config.axiosInstance) {
+    // use passed axios instance
+    instance = config.axiosInstance
+  } else {
+    const combinedConfig = merge(DEFAULT_CONFIG, dissoc('headers', config))
+    // create the axios instance
+    instance = axios.create(combinedConfig)
+  }
+  
   const monitors = []
   const addMonitor = monitor => {
     monitors.push(monitor)

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,6 +1,7 @@
 import test from 'ava'
 import { create, DEFAULT_HEADERS } from '../lib/apisauce'
 import { merge } from 'ramda'
+import axios from 'axios'
 
 const validConfig = {
   baseURL: 'http://localhost:9991',
@@ -19,8 +20,18 @@ test('returns an object when we configure correctly', t => {
 
 test('configures axios correctly', t => {
   const apisauce = create(validConfig)
-  const axios = apisauce.axiosInstance
-  t.is(axios.defaults.timeout, 0)
-  t.is(axios.defaults.baseURL, validConfig.baseURL)
+  const { axiosInstance } = apisauce
+  t.is(axiosInstance.defaults.timeout, 0)
+  t.is(axiosInstance.defaults.baseURL, validConfig.baseURL)
   t.deepEqual(apisauce.headers, merge(DEFAULT_HEADERS, validConfig.headers))
 })
+
+test('configures axios correctly with passed instance', t => {
+  const customAxiosInstance = axios.create({ baseURL: validConfig.baseURL })
+  const apisauce = create({ axiosInstance: customAxiosInstance, headers: validConfig.headers })
+  const { axiosInstance } = apisauce
+  t.is(axiosInstance.defaults.timeout, 0)
+  t.is(axiosInstance.defaults.baseURL, validConfig.baseURL)
+  t.deepEqual(apisauce.headers, merge(DEFAULT_HEADERS, validConfig.headers))
+})
+


### PR DESCRIPTION
This PR add the ability to pass the already created axios instance in the config. This is issue [#205](https://github.com/infinitered/apisauce/issues/205).