### PR TITLE
axiosInstance should be optional in ApisauceConfig

### DIFF
--- a/apisauce.d.ts
+++ b/apisauce.d.ts
@@ -25,7 +25,7 @@ export type PROBLEM_CODE =
 
 export interface ApisauceConfig extends AxiosRequestConfig {
   baseURL: string | undefined;
-  axiosInstance: AxiosInstance | undefined;
+  axiosInstance?: AxiosInstance;
 }
 
 /**


### PR DESCRIPTION
Fixes type issue in https://github.com/infinitered/apisauce/pull/222