### PR TITLE
Utilizes ApiErrorResponse<U> in all of the HTTP methods

### DIFF
--- a/apisauce.d.ts
+++ b/apisauce.d.ts
@@ -1,8 +1,8 @@
-import {AxiosInstance, AxiosRequestConfig, AxiosError, CancelTokenStatic} from 'axios';
+import { AxiosInstance, AxiosRequestConfig, AxiosError, CancelTokenStatic } from 'axios'
 
-export type HEADERS = { [key: string]: string };
+export type HEADERS = { [key: string]: string }
 export const DEFAULT_HEADERS: {
-  Accept: 'application/json',
+  Accept: 'application/json'
   'Content-Type': 'application/json'
 }
 
@@ -15,103 +15,105 @@ export const NETWORK_ERROR: 'NETWORK_ERROR'
 export const UNKNOWN_ERROR: 'UNKNOWN_ERROR'
 export const CANCEL_ERROR: 'CANCEL_ERROR'
 export type PROBLEM_CODE =
-  'CLIENT_ERROR' |
-  'SERVER_ERROR' |
-  'TIMEOUT_ERROR' |
-  'CONNECTION_ERROR' |
-  'NETWORK_ERROR' |
-  'UNKNOWN_ERROR' |
-  'CANCEL_ERROR';
+  | 'CLIENT_ERROR'
+  | 'SERVER_ERROR'
+  | 'TIMEOUT_ERROR'
+  | 'CONNECTION_ERROR'
+  | 'NETWORK_ERROR'
+  | 'UNKNOWN_ERROR'
+  | 'CANCEL_ERROR'
 
 export interface ApisauceConfig extends AxiosRequestConfig {
-  baseURL: string | undefined;
-  axiosInstance?: AxiosInstance;
+  baseURL: string | undefined
+  axiosInstance?: AxiosInstance
 }
 
 /**
  * Creates a instance of our API using the configuration
  * @param config a configuration object which must have a non-empty 'baseURL' property.
  */
-export function create(config: ApisauceConfig): ApisauceInstance;
+export function create(config: ApisauceConfig): ApisauceInstance
 
 export interface ApiErrorResponse<T> {
-  ok: false;
-  problem: PROBLEM_CODE;
-  originalError: AxiosError;
+  ok: false
+  problem: PROBLEM_CODE
+  originalError: AxiosError
 
-  data?: T;
-  status?: number;
-  headers?: {};
-  config?: AxiosRequestConfig;
-  duration?: number;
+  data?: T
+  status?: number
+  headers?: {}
+  config?: AxiosRequestConfig
+  duration?: number
 }
 export interface ApiOkResponse<T> {
-  ok: true;
-  problem: null;
-  originalError: null;
+  ok: true
+  problem: null
+  originalError: null
 
-  data?: T;
-  status?: number;
-  headers?: {};
-  config?: AxiosRequestConfig;
-  duration?: number;
+  data?: T
+  status?: number
+  headers?: {}
+  config?: AxiosRequestConfig
+  duration?: number
 }
-export type ApiResponse<T, U = T> = ApiErrorResponse<U> | ApiOkResponse<T>;
+export type ApiResponse<T, U = T> = ApiErrorResponse<U> | ApiOkResponse<T>
 
-export type Monitor = (response: ApiResponse<any>) => void;
-export type RequestTransform = (request: AxiosRequestConfig) => void;
-export type AsyncRequestTransform = (request: AxiosRequestConfig) => (Promise<void> | ((request: AxiosRequestConfig) => Promise<void>));
-export type ResponseTransform = (response: ApiResponse<any>) => void;
+export type Monitor = (response: ApiResponse<any>) => void
+export type RequestTransform = (request: AxiosRequestConfig) => void
+export type AsyncRequestTransform = (
+  request: AxiosRequestConfig,
+) => Promise<void> | ((request: AxiosRequestConfig) => Promise<void>)
+export type ResponseTransform = (response: ApiResponse<any>) => void
 
 export interface ApisauceInstance {
-  axiosInstance: AxiosInstance;
+  axiosInstance: AxiosInstance
 
-  monitors: Monitor;
-  addMonitor: (monitor: Monitor) => void;
+  monitors: Monitor
+  addMonitor: (monitor: Monitor) => void
 
-  requestTransforms: RequestTransform[];
-  asyncRequestTransforms: AsyncRequestTransform[];
-  responseTransforms: ResponseTransform[];
-  addRequestTransform: (transform: RequestTransform) => void;
-  addAsyncRequestTransform: (transform: AsyncRequestTransform) => void;
-  addResponseTransform: (transform: ResponseTransform) => void;
+  requestTransforms: RequestTransform[]
+  asyncRequestTransforms: AsyncRequestTransform[]
+  responseTransforms: ResponseTransform[]
+  addRequestTransform: (transform: RequestTransform) => void
+  addAsyncRequestTransform: (transform: AsyncRequestTransform) => void
+  addResponseTransform: (transform: ResponseTransform) => void
 
-  headers: HEADERS;
-  setHeader: (key: string, value: string) => AxiosInstance;
-  setHeaders: (headers: HEADERS) => AxiosInstance;
-  deleteHeader: (name: string) => AxiosInstance;
+  headers: HEADERS
+  setHeader: (key: string, value: string) => AxiosInstance
+  setHeaders: (headers: HEADERS) => AxiosInstance
+  deleteHeader: (name: string) => AxiosInstance
 
   /** Sets a new base URL */
-  setBaseURL: (baseUrl: string) => AxiosInstance;
+  setBaseURL: (baseUrl: string) => AxiosInstance
   /** Gets the current base URL used by axios */
-  getBaseURL: () => string;
+  getBaseURL: () => string
 
-  get: <T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T>>;
-  delete: <T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T>>;
-  head: <T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T>>;
-  post: <T>(url: string, data?: any, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T>>;
-  put: <T>(url: string, data?: any, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T>>;
-  patch: <T>(url: string, data?: any, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T>>;
-  link: <T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T>>;
-  unlink: <T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T>>;
+  get: <T, U = T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T, U>>
+  delete: <T, U = T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T, U>>
+  head: <T, U = T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T, U>>
+  post: <T, U = T>(url: string, data?: any, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T, U>>
+  put: <T, U = T>(url: string, data?: any, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T, U>>
+  patch: <T, U = T>(url: string, data?: any, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T, U>>
+  link: <T, U = T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T, U>>
+  unlink: <T, U = T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T, U>>
 }
 
-export function isCancel(value: any): boolean;
+export function isCancel(value: any): boolean
 
-export const CancelToken: CancelTokenStatic;
+export const CancelToken: CancelTokenStatic
 
 declare const _default: {
-  DEFAULT_HEADERS: typeof DEFAULT_HEADERS;
-  NONE: typeof NONE;
-  CLIENT_ERROR: typeof CLIENT_ERROR;
-  SERVER_ERROR: typeof SERVER_ERROR;
-  TIMEOUT_ERROR: typeof TIMEOUT_ERROR;
-  CONNECTION_ERROR: typeof CONNECTION_ERROR;
-  NETWORK_ERROR: typeof NETWORK_ERROR;
-  UNKNOWN_ERROR: typeof UNKNOWN_ERROR;
-  create: typeof create;
-  isCancel: typeof isCancel;
-  CancelToken: typeof CancelToken;
+  DEFAULT_HEADERS: typeof DEFAULT_HEADERS
+  NONE: typeof NONE
+  CLIENT_ERROR: typeof CLIENT_ERROR
+  SERVER_ERROR: typeof SERVER_ERROR
+  TIMEOUT_ERROR: typeof TIMEOUT_ERROR
+  CONNECTION_ERROR: typeof CONNECTION_ERROR
+  NETWORK_ERROR: typeof NETWORK_ERROR
+  UNKNOWN_ERROR: typeof UNKNOWN_ERROR
+  create: typeof create
+  isCancel: typeof isCancel
+  CancelToken: typeof CancelToken
 }
 
-export default _default;
+export default _default


### PR DESCRIPTION
Hi! 

This is a follow up to #219, which introduced a second type parameter used when the error response has a different structure. However, when adding types to actual API calls (HTTP methods) I noticed that this ApiErrorResponse type is not utilized.

This PR fixes it by adding a second parameter `U = T` to all HTTP method calls.

All the remaining changes are style fixes introduced by linter commit hook.