### PR TITLE
Update axios to v0.21.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     ]
   },
   "dependencies": {
-    "axios": "^0.19.0",
+    "axios": "^0.21.0",
     "ramda": "^0.25.0"
   },
   "description": "Axios + standardized errors + request/response transforms.",


### PR DESCRIPTION
I [discovered an issue](https://github.com/facebook/react-native/issues/30181) when using apisauce with one of our endpoints.
Our server runs on ASP.NET and returns a byte order mark in responses. Axios wasn't correctly handling this prior to v0.20.0-0 which meant JSON.parse would blow up.
Axios released v0.20.0-0 and v0.20.0 which fixed this particular issue, but introduced a TypeScript compilation error which has been fixed in v0.21.0.

More info:
- https://github.com/axios/axios/releases/tag/v0.21.0
- https://github.com/axios/axios/releases/tag/v0.20.0-0