### PR TITLE
feat(deps): Update axios to v0.21.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     ]
   },
   "dependencies": {
-    "axios": "^0.21.0",
+    "axios": "^0.21.1",
     "ramda": "^0.25.0"
   },
   "description": "Axios + standardized errors + request/response transforms.",


### PR DESCRIPTION
This PR updates `axios` to version `0.21.1` due the [SSRF vulnerability](https://snyk.io/vuln/SNYK-JS-AXIOS-1038255) found in previous versions