### PR TITLE
Include umd build in release

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "files": [
     "dist/apisauce.js",
+    "dist/umd/apisauce.js",
     "apisauce.d.ts"
   ],
   "keywords": [


### PR DESCRIPTION
In https://github.com/infinitered/apisauce/pull/260 I forgot that the new umd build also needs to be included in the package.json "files" section to be included in releases. Sorry about that @chakrihacker.

Any chance you could merge this, and release as 2.1.1 or something? Thanks again for considering!