### PR TITLE
fix: update axios and fix default value for 'data'

### DIFF
--- a/lib/apisauce.ts
+++ b/lib/apisauce.ts
@@ -202,7 +202,7 @@ export const create = config => {
   /**
    * Make the request for POST, PUT, PATCH
    */
-  const doRequestWithBody = (method, url, data = null, axiosConfig = {}) => {
+  const doRequestWithBody = (method, url, data, axiosConfig = {}) => {
     return doRequest(merge({ url, method, data }, axiosConfig))
   }
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     ]
   },
   "dependencies": {
-    "axios": "^0.21.1",
+    "axios": "^0.21.4",
     "ramda": "^0.25.0"
   },
   "description": "Axios + standardized errors + request/response transforms.",


### PR DESCRIPTION
- Update `axios` to latest, in order to pick up vulnerability fix
- Don't default to `null` for POST `data`, since `axios` will JSON.stringify that as "null" (instead of sending an empty payload, as before)

I verified locally with my app. When only updating `axios` to 0.21.4 (using yarn's `resolutions` feature), my app was broken as one of my POST requests was sending "null" as the payload body. With this PR, it's working as expected: an empty payload instead.

Fixes https://github.com/infinitered/apisauce/issues/276