### PR TITLE
Removing Ramda (from prod build) and going from 19k to 6k

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,5 @@
 {
-  "presets": [ "es2015" ],
-  "plugins": [ "ramda" ],
+  "presets": ["es2015"],
   "ignore": "test/*",
   "env": {
     "development": {

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ api.patch('/servers/1', { live: false })
 api.put('/servers/1', { live: true })
 api.link('/images/my_dog.jpg', {}, { headers: { Link: '<http://example.com/profiles/joe>; rel="tag"' } })
 api.unlink('/images/my_dog.jpg', {}, { headers: { Link: '<http://example.com/profiles/joe>; rel="tag"' } })
-api.any({ method: 'GET' url: '/product', params: { id: 1 } })
+api.any({ method: 'GET', url: '/product', params: { id: 1 } })
 ```
 
 `get`, `head`, `delete`, `link` and `unlink` accept 3 parameters:

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Talking to APIs doesn't have to be awkward anymore.
 `npm i apisauce --save` or `yarn add apisauce`
 
 - Depends on `axios`.
-- Targets ES5.
-- Built with ES6.
-- Supported in Node and the browser(s) and React Native.
+- Compatible with ES5.
+- Built with TypeScript.
+- Supports Node, the browser, and React Native.
 
 # Quick Start
 
@@ -267,7 +267,7 @@ api.addResponseTransform(response => {
 Or make it async:
 
 ```js
-api.addAsyncResponseTransform(async (response) => {
+api.addAsyncResponseTransform(async response => {
   const something = await AsyncStorage.load('something')
   if (something) {
     // just mutate the data to what you want.
@@ -335,7 +335,7 @@ console.log(response.ok) // yay!
 # Cancel Request
 
 ```js
-import {CancelToken} from 'apisauce'
+import { CancelToken } from 'apisauce'
 
 const source = CancelToken.source()
 const api = create({ baseURL: 'github.com' })

--- a/apisauce.d.ts
+++ b/apisauce.d.ts
@@ -93,15 +93,15 @@ export interface ApisauceInstance {
   /** Gets the current base URL used by axios */
   getBaseURL: () => string
 
-  any: <T, U = T>(config: AxiosRequestConfig) => Promise<ApiResponse<T, U>>
-  get: <T, U = T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T, U>>
-  delete: <T, U = T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T, U>>
-  head: <T, U = T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T, U>>
-  post: <T, U = T>(url: string, data?: any, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T, U>>
-  put: <T, U = T>(url: string, data?: any, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T, U>>
-  patch: <T, U = T>(url: string, data?: any, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T, U>>
-  link: <T, U = T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T, U>>
-  unlink: <T, U = T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T, U>>
+  any: <T, U = T>(config: AxiosRequestConfig<T>) => Promise<ApiResponse<T, U>>
+  get: <T, U = T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig<T>) => Promise<ApiResponse<T, U>>
+  delete: <T, U = T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig<T>) => Promise<ApiResponse<T, U>>
+  head: <T, U = T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig<T>) => Promise<ApiResponse<T, U>>
+  post: <T, U = T>(url: string, data?: any, axiosConfig?: AxiosRequestConfig<T>) => Promise<ApiResponse<T, U>>
+  put: <T, U = T>(url: string, data?: any, axiosConfig?: AxiosRequestConfig<T>) => Promise<ApiResponse<T, U>>
+  patch: <T, U = T>(url: string, data?: any, axiosConfig?: AxiosRequestConfig<T>) => Promise<ApiResponse<T, U>>
+  link: <T, U = T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig<T>) => Promise<ApiResponse<T, U>>
+  unlink: <T, U = T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig<T>) => Promise<ApiResponse<T, U>>
 }
 
 export function isCancel(value: any): boolean

--- a/examples/github.js
+++ b/examples/github.js
@@ -2,22 +2,18 @@ import apisauce from '../lib/apisauce'
 import R from 'ramda'
 import RS from 'ramdasauce'
 
-const REPO = 'skellock/apisauce'
+const REPO = 'infinitered/apisauce'
 
 const api = apisauce.create({
   baseURL: 'https://api.github.com',
   headers: {
-    Accept: 'application/vnd.github.v3+json'
-  }
+    Accept: 'application/vnd.github.v3+json',
+  },
 })
 
 // attach a monitor that fires with each request
 api.addMonitor(
-  R.pipe(
-    RS.dotPath('headers.x-ratelimit-remaining'),
-    R.concat('Calls remaining this hour: '),
-    console.log
-  )
+  R.pipe(RS.dotPath('headers.x-ratelimit-remaining'), R.concat('Calls remaining this hour: '), console.log),
 )
 
 // show the latest commit message

--- a/examples/github.js
+++ b/examples/github.js
@@ -1,6 +1,4 @@
-import apisauce from '../lib/apisauce'
-import R from 'ramda'
-import RS from 'ramdasauce'
+const apisauce = require('../dist/apisauce.js')
 
 const REPO = 'infinitered/apisauce'
 
@@ -12,19 +10,18 @@ const api = apisauce.create({
 })
 
 // attach a monitor that fires with each request
-api.addMonitor(
-  R.pipe(RS.dotPath('headers.x-ratelimit-remaining'), R.concat('Calls remaining this hour: '), console.log),
-)
+api.addMonitor(response => {
+  const info = `Calls remaining this hour: ${response.headers['x-ratelimit-remaining']}`
+  console.log(info)
+})
 
 // show the latest commit message
-api
-  .get(`/repos/${REPO}/commits`)
-  .then(RS.dotPath('data.0.commit.message'))
-  .then(R.concat('Latest Commit: '))
-  .then(console.log)
+api.get(`/repos/${REPO}/commits`).then(response => {
+  const info = `Latest Commit: ${response.data[0].commit.message}`
+  console.log(info)
+})
 
 // call a non-existant API to show that the flow is identical!
-api
-  .post('/something/bad')
-  .then(R.props(['ok', 'status', 'problem']))
-  .then(console.log)
+api.post('/something/bad').then(({ ok, status, problem }) => {
+  console.log({ ok, status, problem })
+})

--- a/lib/apisauce.ts
+++ b/lib/apisauce.ts
@@ -99,13 +99,10 @@ export const getProblemFromError = error => {
   if (axios.isCancel(error)) return CANCEL_ERROR
 
   // then check the specific error code
-  return cond([
-    // if we don't have an error code, we have a response status
-    [isNil, () => getProblemFromStatus(error.response.status)],
-    [containsText(TIMEOUT_ERROR_CODES), always(TIMEOUT_ERROR)],
-    [containsText(NODEJS_CONNECTION_ERROR_CODES), always(CONNECTION_ERROR)],
-    [T, always(UNKNOWN_ERROR)],
-  ])(error.code)
+  if (!error.code) return getProblemFromStatus(error.response.status)
+  if (TIMEOUT_ERROR_CODES.includes(error.code)) return TIMEOUT_ERROR
+  if (NODEJS_CONNECTION_ERROR_CODES.includes(error.code)) return CONNECTION_ERROR
+  return UNKNOWN_ERROR
 }
 
 type StatusCodes = undefined | number

--- a/lib/apisauce.ts
+++ b/lib/apisauce.ts
@@ -2,8 +2,6 @@ import axios, { AxiosResponse, AxiosError } from 'axios'
 import {
   cond,
   isNil,
-  identity,
-  is,
   T,
   curry,
   curryN,
@@ -56,10 +54,7 @@ const toNumber = (value: any): number => {
  * isWithin(1, 5, 5) //=> true
  * isWithin(1, 5, 5.1) //=> false
  */
-const isWithin = curryN(3, (min, max, value) => {
-  const isNumber = is(Number)
-  return isNumber(min) && isNumber(max) && isNumber(value) && gte(value, min) && gte(max, value)
-})
+const isWithin = (min: number, max: number, value: number): boolean => value >= min && value <= max
 
 // a workaround to deal with __ not being available from the ramda types in typescript
 const containsText = curryN(2, (textToSearch, list) => contains(list, textToSearch))
@@ -92,9 +87,9 @@ export const CANCEL_ERROR = 'CANCEL_ERROR'
 
 const TIMEOUT_ERROR_CODES = ['ECONNABORTED']
 const NODEJS_CONNECTION_ERROR_CODES = ['ENOTFOUND', 'ECONNREFUSED', 'ECONNRESET']
-const in200s = isWithin(200, 299)
-const in400s = isWithin(400, 499)
-const in500s = isWithin(500, 599)
+const in200s = (n: number): boolean => isWithin(200, 299, n)
+const in400s = (n: number): boolean => isWithin(400, 499, n)
+const in500s = (n: number): boolean => isWithin(500, 599, n)
 const statusNil = ifElse(isNil, always(undefined), prop('status'))
 
 /**

--- a/lib/apisauce.ts
+++ b/lib/apisauce.ts
@@ -32,11 +32,12 @@ import {
  * @example
  * toNumber('7') //=> 7
  */
-const toNumber = cond([
-  [isNil, identity],
-  [is(Number), identity],
-  [T, x => Number(x)],
-])
+const toNumber = (value: any): number => {
+  if (typeof value === 'number' || value === null || value === undefined) {
+    return value
+  }
+  return Number(value)
+}
 
 /**
  * Given a min and max, determines if the value is included

--- a/lib/apisauce.ts
+++ b/lib/apisauce.ts
@@ -220,12 +220,6 @@ export const create = config => {
       return runMonitors(ourResponse)
     }
 
-    // const chain = pipeP(
-    //   convertResponse(toNumber(new Date())),
-    //   // partial(convertResponse, [toNumber(new Date())]),
-    //   runMonitors,
-    // )
-
     return instance
       .request(axiosRequestConfig)
       .then(chain)

--- a/lib/apisauce.ts
+++ b/lib/apisauce.ts
@@ -2,7 +2,6 @@ import axios, { AxiosResponse, AxiosError } from 'axios'
 
 // prettier-ignore
 import {
-  curry,
   merge,
   dissoc,
   keys,
@@ -242,6 +241,18 @@ export const create = config => {
       }
     })
     return ourResponse
+  }
+
+  /**
+   * Turns a function into a curried function.
+   */
+  const curry = fn => {
+    return (...args) => {
+      if (args.length >= fn.length) {
+        return fn(...args)
+      }
+      return curry(fn.bind(null, ...args))
+    }
   }
 
   /**

--- a/lib/apisauce.ts
+++ b/lib/apisauce.ts
@@ -2,10 +2,6 @@ import axios, { AxiosResponse, AxiosError } from 'axios'
 
 // prettier-ignore
 import {
-  merge,
-  dissoc,
-  keys,
-  forEach,
   pipeP,
   partial,
 } from 'ramda'
@@ -120,7 +116,8 @@ export const create = config => {
     // use passed axios instance
     instance = config.axiosInstance
   } else {
-    const combinedConfig = merge(DEFAULT_CONFIG, dissoc('headers', config))
+    const configWithoutHeaders = { ...config, headers: undefined }
+    const combinedConfig = { ...DEFAULT_CONFIG, ...configWithoutHeaders }
     // create the axios instance
     instance = axios.create(combinedConfig)
   }
@@ -148,7 +145,7 @@ export const create = config => {
 
   // sets headers in bulk
   const setHeaders = headers => {
-    forEach(header => setHeader(header, headers[header]), keys(headers))
+    Object.keys(headers).forEach(header => setHeader(header, headers[header]))
     return instance
   }
 
@@ -200,7 +197,7 @@ export const create = config => {
     if (requestTransforms.length > 0) {
       // overwrite our axios request with whatever our object looks like now
       // axiosRequestConfig = doRequestTransforms(requestTransforms, axiosRequestConfig)
-      forEach(transform => transform(axiosRequestConfig), requestTransforms)
+      requestTransforms.forEach(transform => transform(axiosRequestConfig))
     }
 
     // add the async request transforms
@@ -287,7 +284,7 @@ export const create = config => {
       data,
     }
     if (responseTransforms.length > 0) {
-      forEach(transform => transform(transformedResponse), responseTransforms)
+      responseTransforms.forEach(transform => transform(transformedResponse))
     }
 
     // add the async response transforms

--- a/lib/apisauce.ts
+++ b/lib/apisauce.ts
@@ -2,19 +2,13 @@ import axios, { AxiosResponse, AxiosError } from 'axios'
 
 // prettier-ignore
 import {
-  cond,
-  isNil,
-  T,
   curry,
-  curryN,
   merge,
   dissoc,
   keys,
   forEach,
   pipeP,
   partial,
-  contains,
-  always,
 } from 'ramda'
 
 /**
@@ -54,9 +48,6 @@ const toNumber = (value: any): number => {
  * isWithin(1, 5, 5.1) //=> false
  */
 const isWithin = (min: number, max: number, value: number): boolean => value >= min && value <= max
-
-// a workaround to deal with __ not being available from the ramda types in typescript
-const containsText = curryN(2, (textToSearch, list) => contains(list, textToSearch))
 
 /**
  * Are we dealing with a promise?
@@ -123,7 +114,7 @@ export const getProblemFromStatus = (status: StatusCodes) => {
  */
 export const create = config => {
   // combine the user's headers with ours
-  const headers = merge(DEFAULT_HEADERS, config.headers || {})
+  const headers = { ...DEFAULT_HEADERS, ...(config.headers || {}) }
 
   let instance
   if (config.axiosInstance) {
@@ -187,14 +178,14 @@ export const create = config => {
    * Make the request for GET, HEAD, DELETE
    */
   const doRequestWithoutBody = (method, url, params = {}, axiosConfig = {}) => {
-    return doRequest(merge({ url, params, method }, axiosConfig))
+    return doRequest({ ...axiosConfig, url, params, method })
   }
 
   /**
    * Make the request for POST, PUT, PATCH
    */
   const doRequestWithBody = (method, url, data, axiosConfig = {}) => {
-    return doRequest(merge({ url, method, data }, axiosConfig))
+    return doRequest({ ...axiosConfig, url, method, data })
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.2",
+  "version": "2.1.3",
   "author": "Steve Kellock <steve@kellock.ca>",
   "ava": {
     "require": [

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     ]
   },
   "dependencies": {
-    "axios": "^0.21.4",
-    "ramda": "^0.25.0"
+    "axios": "^0.21.4"
   },
   "description": "Axios + standardized errors + request/response transforms.",
   "devDependencies": {
@@ -19,7 +18,6 @@
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-eslint": "^8.2.3",
-    "babel-plugin-ramda": "^1.6.1",
     "babel-preset-es2015": "^6.24.1",
     "husky": "^1.3.1",
     "lint-staged": "^8.1.0",
@@ -27,6 +25,7 @@
     "npm-run-all": "^4.1.5",
     "nyc": "^11.8.0",
     "prettier": "^1.15.3",
+    "ramda": "^0.25.0",
     "ramdasauce": "^2.1.0",
     "rollup": "^0.59.1",
     "rollup-plugin-babel": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "version": "2.1.3",
-  "author": "Steve Kellock <steve@kellock.ca>",
+  "author": {
+    "name": "Infinite Red",
+    "email": "npm@infinite.red",
+    "url": "https://github.com/infinitered/ignite"
+  },
   "ava": {
     "require": [
       "babel-core/register"
@@ -55,7 +59,7 @@
   "name": "apisauce",
   "repository": {
     "type": "git",
-    "url": "https://github.com/skellock/apisauce.git"
+    "url": "https://github.com/infinitered/apisauce.git"
   },
   "scripts": {
     "build": "BABEL_ENV=production rollup -c",
@@ -69,7 +73,8 @@
     "test:unit": "ava -s",
     "ci:publish": "yarn semantic-release",
     "semantic-release": "semantic-release",
-    "format": "prettier --write \"{**/*.ts,.circleci/**/*.js}\" --loglevel error && tslint -p . --fix"
+    "format": "prettier --write \"{**/*.ts,.circleci/**/*.js}\" --loglevel error && tslint -p . --fix",
+    "example": "node ./examples/github.js"
   },
   "prettier": {
     "semi": false,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,11 +4,11 @@ import filesize from 'rollup-plugin-filesize'
 import resolve from 'rollup-plugin-node-resolve'
 import uglify from 'rollup-plugin-uglify'
 
-const externalModules = ['ramda', 'axios']
+const externalModules = ['axios']
 const input = 'lib/apisauce.js'
 const name = 'apisauce'
 
-function isImportExternal (importStr) {
+function isImportExternal(importStr) {
   let external = false
 
   // Check for each of the external modules defined above
@@ -19,8 +19,8 @@ function isImportExternal (importStr) {
   return external
 }
 
-function getBabelOptions () {
-  return { babelrc: false, plugins: ['ramda'] }
+function getBabelOptions() {
+  return { babelrc: false, plugins: [] }
 }
 
 export default [
@@ -31,12 +31,8 @@ export default [
       file: `dist/${name}.js`,
       format: 'cjs',
     },
-    plugins: [
-      babel(getBabelOptions()),
-      uglify(),
-      filesize()
-    ],
-    external: isImportExternal
+    plugins: [babel(getBabelOptions()), uglify(), filesize()],
+    external: isImportExternal,
   },
   {
     input,
@@ -45,18 +41,11 @@ export default [
       file: `dist/umd/${name}.js`,
       format: 'umd',
       globals: {
-        'ramda': 'ramda',
-        'axios': 'axios'
+        axios: 'axios',
       },
       name,
     },
-    plugins: [
-      babel(getBabelOptions()),
-      resolve(),
-      commonjs(),
-      uglify(),
-      filesize()
-    ],
+    plugins: [babel(getBabelOptions()), resolve(), commonjs(), uglify(), filesize()],
     external: externalModules,
   },
 ]

--- a/test/_server.js
+++ b/test/_server.js
@@ -6,11 +6,11 @@ const processPost = (request, response, callback) => {
   let queryData = ''
   if (typeof callback !== 'function') return null
 
-  request.on('data', function (data) {
+  request.on('data', function(data) {
     queryData += data
   })
 
-  request.on('end', function () {
+  request.on('end', function() {
     request.post = JSON.parse(queryData)
     callback()
   })
@@ -55,7 +55,7 @@ export default (port, mockData = {}) => {
     }
 
     if (url === '/post') {
-      processPost(req, res, function () {
+      processPost(req, res, function() {
         sendResponse(res, 200, JSON.stringify({ got: req.post }))
       })
     }

--- a/test/_server.js
+++ b/test/_server.js
@@ -27,40 +27,40 @@ const send200 = (res, body) => {
 }
 
 export default (port, mockData = {}) => {
-  const server = http.createServer((req, res) => {
-    const url = req.url
-    if (url === '/ok') {
-      send200(res)
-      return
-    }
-
-    if (RS.startsWith('/echo', url)) {
-      const echo = R.slice(8, Infinity, url)
-      sendResponse(res, 200, JSON.stringify({ echo }))
-      return
-    }
-
-    if (RS.startsWith('/number', url)) {
-      const n = R.slice(8, 11, url)
-      sendResponse(res, n, JSON.stringify(mockData))
-      return
-    }
-
-    if (RS.startsWith('/sleep', url)) {
-      const wait = R.pipe(R.split('/'), R.last, Number)(url)
-      setTimeout(() => {
+  return new Promise(resolve => {
+    const server = http.createServer((req, res) => {
+      const url = req.url
+      if (url === '/ok') {
         send200(res)
-      }, wait)
-      return
-    }
+        return
+      }
 
-    if (url === '/post') {
-      processPost(req, res, function() {
-        sendResponse(res, 200, JSON.stringify({ got: req.post }))
-      })
-    }
+      if (RS.startsWith('/echo', url)) {
+        const echo = R.slice(8, Infinity, url)
+        sendResponse(res, 200, JSON.stringify({ echo }))
+        return
+      }
+
+      if (RS.startsWith('/number', url)) {
+        const n = R.slice(8, 11, url)
+        sendResponse(res, n, JSON.stringify(mockData))
+        return
+      }
+
+      if (RS.startsWith('/sleep', url)) {
+        const wait = R.pipe(R.split('/'), R.last, Number)(url)
+        setTimeout(() => {
+          send200(res)
+        }, wait)
+        return
+      }
+
+      if (url === '/post') {
+        processPost(req, res, function() {
+          sendResponse(res, 200, JSON.stringify({ got: req.post }))
+        })
+      }
+    })
+    server.listen(port, 'localhost', () => resolve(server))
   })
-  server.listen(port, 'localhost')
-
-  return server
 }

--- a/test/async-request-transform.test.js
+++ b/test/async-request-transform.test.js
@@ -21,7 +21,7 @@ const delay = time =>
 
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port, MOCK)
+  server = await createServer(port, MOCK)
 })
 
 test.after('cleanup', t => {
@@ -195,7 +195,7 @@ test('headers can be created', t => {
 test('headers from creation time can be changed', t => {
   const x = create({
     baseURL: `http://localhost:${port}`,
-    headers: { 'X-APISAUCE': 'hello' }
+    headers: { 'X-APISAUCE': 'hello' },
   })
   x.addAsyncRequestTransform(req => {
     return new Promise((resolve, reject) => {
@@ -215,7 +215,7 @@ test('headers from creation time can be changed', t => {
 test('headers can be deleted', t => {
   const x = create({
     baseURL: `http://localhost:${port}`,
-    headers: { 'X-APISAUCE': 'omg' }
+    headers: { 'X-APISAUCE': 'omg' },
   })
   x.addAsyncRequestTransform(req => {
     return new Promise((resolve, reject) => {

--- a/test/async-response-transform.test.js
+++ b/test/async-response-transform.test.js
@@ -9,7 +9,7 @@ let port
 let server = null
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port, MOCK)
+  server = await createServer(port, MOCK)
 })
 
 test.after('cleanup', t => {
@@ -37,7 +37,7 @@ test('alters the response', t => {
         data.a = 'hi'
         resolve(data)
       })
-    })    
+    })
   })
   t.is(count, 0)
   return x.get('/number/201').then(response => {

--- a/test/async.test.js
+++ b/test/async.test.js
@@ -8,7 +8,7 @@ let server = null
 const MOCK = { a: { b: [1, 2, 3] } }
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port, MOCK)
+  server = await createServer(port, MOCK)
 })
 
 test.after.always('cleanup', t => {

--- a/test/cancellation.test.js
+++ b/test/cancellation.test.js
@@ -7,7 +7,7 @@ let port
 let server = null
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port)
+  server = await createServer(port)
 })
 
 test.after('cleanup', t => {
@@ -19,7 +19,7 @@ test('cancel request', t => {
   const x = create({
     baseURL: `http://localhost:${port}`,
     cancelToken: source.token,
-    timeout: 200
+    timeout: 200,
   })
   setTimeout(() => {
     source.cancel()

--- a/test/data.test.js
+++ b/test/data.test.js
@@ -8,7 +8,7 @@ let port
 let server = null
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port, MOCK)
+  server = await createServer(port, MOCK)
 })
 
 test.after.always('cleanup', t => {

--- a/test/headers.test.js
+++ b/test/headers.test.js
@@ -8,7 +8,7 @@ let port
 let server = null
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port, MOCK)
+  server = await createServer(port, MOCK)
 })
 
 test.after('cleanup', t => {
@@ -18,7 +18,7 @@ test.after('cleanup', t => {
 test('jumps the wire with the right headers', async t => {
   const api = create({
     baseURL: `http://localhost:${port}`,
-    headers: { 'X-Testing': 'hello' }
+    headers: { 'X-Testing': 'hello' },
   })
   api.setHeaders({ 'X-Testing': 'foo', steve: 'hey' })
   const response = await api.get('/number/200', { a: 'b' })

--- a/test/monitor.test.js
+++ b/test/monitor.test.js
@@ -9,7 +9,7 @@ let port
 let server = null
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port, MOCK)
+  server = await createServer(port, MOCK)
 })
 
 test.after('cleanup', t => {

--- a/test/params.test.js
+++ b/test/params.test.js
@@ -7,7 +7,7 @@ let port
 let server = null
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port)
+  server = await createServer(port)
 })
 
 test.after('cleanup', t => {

--- a/test/post-data.test.js
+++ b/test/post-data.test.js
@@ -8,7 +8,7 @@ let port
 let server = null
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port, MOCK)
+  server = await createServer(port, MOCK)
 })
 
 test.after('cleanup', t => {

--- a/test/request-transform.test.js
+++ b/test/request-transform.test.js
@@ -9,7 +9,7 @@ let port
 let server = null
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port, MOCK)
+  server = await createServer(port, MOCK)
 })
 
 test.after('cleanup', t => {
@@ -107,7 +107,7 @@ test('headers can be created', t => {
 test('headers from creation time can be changed', t => {
   const x = create({
     baseURL: `http://localhost:${port}`,
-    headers: { 'X-APISAUCE': 'hello' }
+    headers: { 'X-APISAUCE': 'hello' },
   })
   x.addRequestTransform(request => {
     t.is(request.headers['X-APISAUCE'], 'hello')
@@ -122,7 +122,7 @@ test('headers from creation time can be changed', t => {
 test('headers can be deleted', t => {
   const x = create({
     baseURL: `http://localhost:${port}`,
-    headers: { 'X-APISAUCE': 'omg' }
+    headers: { 'X-APISAUCE': 'omg' },
   })
   x.addRequestTransform(request => {
     t.is(request.headers['X-APISAUCE'], 'omg')

--- a/test/response-transform.test.js
+++ b/test/response-transform.test.js
@@ -9,7 +9,7 @@ let port
 let server = null
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port, MOCK)
+  server = await createServer(port, MOCK)
 })
 
 test.after('cleanup', t => {

--- a/test/set-base-url.test.js
+++ b/test/set-base-url.test.js
@@ -8,7 +8,7 @@ let port
 let server = null
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port, MOCK)
+  server = await createServer(port, MOCK)
 })
 
 test.after('cleanup', t => {
@@ -18,7 +18,7 @@ test.after('cleanup', t => {
 test('changes the headers', async t => {
   const api = create({
     baseURL: `http://localhost:${port}`,
-    headers: { 'X-Testing': 'hello' }
+    headers: { 'X-Testing': 'hello' },
   })
   const response1 = await api.get('/number/200')
   t.deepEqual(response1.data, MOCK)

--- a/test/speed.test.js
+++ b/test/speed.test.js
@@ -8,7 +8,7 @@ let port
 let server = null
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port, MOCK)
+  server = await createServer(port, MOCK)
 })
 
 test.after('cleanup', t => {

--- a/test/speed.test.js
+++ b/test/speed.test.js
@@ -17,10 +17,9 @@ test.after('cleanup', t => {
 
 test('has a duration node', async t => {
   const x = create({ baseURL: `http://localhost:${port}` })
-  const speed = 150
-  const response = await x.get(`/sleep/${speed}`)
+  const response = await x.get(`/sleep/150`)
   t.is(response.status, 200)
   t.truthy(response.duration)
   t.truthy(response.duration >= 150)
-  t.truthy(response.duration <= 1000) // fragile
+  // t.truthy(response.duration <= 1000) // fragile
 })

--- a/test/status.test.js
+++ b/test/status.test.js
@@ -7,7 +7,7 @@ let port
 let server = null
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port)
+  server = await createServer(port)
 })
 
 test.after('cleanup', t => {

--- a/test/timeout.test.js
+++ b/test/timeout.test.js
@@ -7,7 +7,7 @@ let port
 let server = null
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port)
+  server = await createServer(port)
 })
 
 test.after('cleanup', t => {

--- a/test/verbs.test.js
+++ b/test/verbs.test.js
@@ -7,7 +7,7 @@ let port
 let server = null
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port)
+  server = await createServer(port)
 })
 
 test.after('cleanup', t => {


### PR DESCRIPTION
This PR removes Ramda from our production build of apisauce. (It's still present in devDependencies because I didn't feel like untangling the tests.)

```
            commonjs    umd
With Ramda:     7.6k  19.2k
Without:        6.6k   5.8k
```

As you can see, the size win is significant -- 1k less for commonjs and 13k less for umd (not sure why umd has such a huge win, but i'll take it).

At some point it would be nice to remove Ramda from the tests too, but that's a chore.
