### PR TITLE
Fixes random test failures by waiting for server to start

### DIFF
--- a/test/_server.js
+++ b/test/_server.js
@@ -6,11 +6,11 @@ const processPost = (request, response, callback) => {
   let queryData = ''
   if (typeof callback !== 'function') return null
 
-  request.on('data', function (data) {
+  request.on('data', function(data) {
     queryData += data
   })
 
-  request.on('end', function () {
+  request.on('end', function() {
     request.post = JSON.parse(queryData)
     callback()
   })
@@ -27,40 +27,40 @@ const send200 = (res, body) => {
 }
 
 export default (port, mockData = {}) => {
-  const server = http.createServer((req, res) => {
-    const url = req.url
-    if (url === '/ok') {
-      send200(res)
-      return
-    }
-
-    if (RS.startsWith('/echo', url)) {
-      const echo = R.slice(8, Infinity, url)
-      sendResponse(res, 200, JSON.stringify({ echo }))
-      return
-    }
-
-    if (RS.startsWith('/number', url)) {
-      const n = R.slice(8, 11, url)
-      sendResponse(res, n, JSON.stringify(mockData))
-      return
-    }
-
-    if (RS.startsWith('/sleep', url)) {
-      const wait = R.pipe(R.split('/'), R.last, Number)(url)
-      setTimeout(() => {
+  return new Promise(resolve => {
+    const server = http.createServer((req, res) => {
+      const url = req.url
+      if (url === '/ok') {
         send200(res)
-      }, wait)
-      return
-    }
+        return
+      }
 
-    if (url === '/post') {
-      processPost(req, res, function () {
-        sendResponse(res, 200, JSON.stringify({ got: req.post }))
-      })
-    }
+      if (RS.startsWith('/echo', url)) {
+        const echo = R.slice(8, Infinity, url)
+        sendResponse(res, 200, JSON.stringify({ echo }))
+        return
+      }
+
+      if (RS.startsWith('/number', url)) {
+        const n = R.slice(8, 11, url)
+        sendResponse(res, n, JSON.stringify(mockData))
+        return
+      }
+
+      if (RS.startsWith('/sleep', url)) {
+        const wait = R.pipe(R.split('/'), R.last, Number)(url)
+        setTimeout(() => {
+          send200(res)
+        }, wait)
+        return
+      }
+
+      if (url === '/post') {
+        processPost(req, res, function() {
+          sendResponse(res, 200, JSON.stringify({ got: req.post }))
+        })
+      }
+    })
+    server.listen(port, 'localhost', () => resolve(server))
   })
-  server.listen(port, 'localhost')
-
-  return server
 }

--- a/test/async-request-transform.test.js
+++ b/test/async-request-transform.test.js
@@ -21,7 +21,7 @@ const delay = time =>
 
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port, MOCK)
+  server = await createServer(port, MOCK)
 })
 
 test.after('cleanup', t => {
@@ -195,7 +195,7 @@ test('headers can be created', t => {
 test('headers from creation time can be changed', t => {
   const x = create({
     baseURL: `http://localhost:${port}`,
-    headers: { 'X-APISAUCE': 'hello' }
+    headers: { 'X-APISAUCE': 'hello' },
   })
   x.addAsyncRequestTransform(req => {
     return new Promise((resolve, reject) => {
@@ -215,7 +215,7 @@ test('headers from creation time can be changed', t => {
 test('headers can be deleted', t => {
   const x = create({
     baseURL: `http://localhost:${port}`,
-    headers: { 'X-APISAUCE': 'omg' }
+    headers: { 'X-APISAUCE': 'omg' },
   })
   x.addAsyncRequestTransform(req => {
     return new Promise((resolve, reject) => {

--- a/test/async-response-transform.test.js
+++ b/test/async-response-transform.test.js
@@ -9,7 +9,7 @@ let port
 let server = null
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port, MOCK)
+  server = await createServer(port, MOCK)
 })
 
 test.after('cleanup', t => {
@@ -37,7 +37,7 @@ test('alters the response', t => {
         data.a = 'hi'
         resolve(data)
       })
-    })    
+    })
   })
   t.is(count, 0)
   return x.get('/number/201').then(response => {

--- a/test/async.test.js
+++ b/test/async.test.js
@@ -8,7 +8,7 @@ let server = null
 const MOCK = { a: { b: [1, 2, 3] } }
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port, MOCK)
+  server = await createServer(port, MOCK)
 })
 
 test.after.always('cleanup', t => {

--- a/test/cancellation.test.js
+++ b/test/cancellation.test.js
@@ -7,7 +7,7 @@ let port
 let server = null
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port)
+  server = await createServer(port)
 })
 
 test.after('cleanup', t => {
@@ -19,7 +19,7 @@ test('cancel request', t => {
   const x = create({
     baseURL: `http://localhost:${port}`,
     cancelToken: source.token,
-    timeout: 200
+    timeout: 200,
   })
   setTimeout(() => {
     source.cancel()

--- a/test/data.test.js
+++ b/test/data.test.js
@@ -8,7 +8,7 @@ let port
 let server = null
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port, MOCK)
+  server = await createServer(port, MOCK)
 })
 
 test.after.always('cleanup', t => {

--- a/test/headers.test.js
+++ b/test/headers.test.js
@@ -8,7 +8,7 @@ let port
 let server = null
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port, MOCK)
+  server = await createServer(port, MOCK)
 })
 
 test.after('cleanup', t => {
@@ -18,7 +18,7 @@ test.after('cleanup', t => {
 test('jumps the wire with the right headers', async t => {
   const api = create({
     baseURL: `http://localhost:${port}`,
-    headers: { 'X-Testing': 'hello' }
+    headers: { 'X-Testing': 'hello' },
   })
   api.setHeaders({ 'X-Testing': 'foo', steve: 'hey' })
   const response = await api.get('/number/200', { a: 'b' })

--- a/test/monitor.test.js
+++ b/test/monitor.test.js
@@ -9,7 +9,7 @@ let port
 let server = null
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port, MOCK)
+  server = await createServer(port, MOCK)
 })
 
 test.after('cleanup', t => {

--- a/test/params.test.js
+++ b/test/params.test.js
@@ -7,7 +7,7 @@ let port
 let server = null
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port)
+  server = await createServer(port)
 })
 
 test.after('cleanup', t => {

--- a/test/post-data.test.js
+++ b/test/post-data.test.js
@@ -8,7 +8,7 @@ let port
 let server = null
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port, MOCK)
+  server = await createServer(port, MOCK)
 })
 
 test.after('cleanup', t => {

--- a/test/request-transform.test.js
+++ b/test/request-transform.test.js
@@ -9,7 +9,7 @@ let port
 let server = null
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port, MOCK)
+  server = await createServer(port, MOCK)
 })
 
 test.after('cleanup', t => {
@@ -107,7 +107,7 @@ test('headers can be created', t => {
 test('headers from creation time can be changed', t => {
   const x = create({
     baseURL: `http://localhost:${port}`,
-    headers: { 'X-APISAUCE': 'hello' }
+    headers: { 'X-APISAUCE': 'hello' },
   })
   x.addRequestTransform(request => {
     t.is(request.headers['X-APISAUCE'], 'hello')
@@ -122,7 +122,7 @@ test('headers from creation time can be changed', t => {
 test('headers can be deleted', t => {
   const x = create({
     baseURL: `http://localhost:${port}`,
-    headers: { 'X-APISAUCE': 'omg' }
+    headers: { 'X-APISAUCE': 'omg' },
   })
   x.addRequestTransform(request => {
     t.is(request.headers['X-APISAUCE'], 'omg')

--- a/test/response-transform.test.js
+++ b/test/response-transform.test.js
@@ -9,7 +9,7 @@ let port
 let server = null
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port, MOCK)
+  server = await createServer(port, MOCK)
 })
 
 test.after('cleanup', t => {

--- a/test/set-base-url.test.js
+++ b/test/set-base-url.test.js
@@ -8,7 +8,7 @@ let port
 let server = null
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port, MOCK)
+  server = await createServer(port, MOCK)
 })
 
 test.after('cleanup', t => {
@@ -18,7 +18,7 @@ test.after('cleanup', t => {
 test('changes the headers', async t => {
   const api = create({
     baseURL: `http://localhost:${port}`,
-    headers: { 'X-Testing': 'hello' }
+    headers: { 'X-Testing': 'hello' },
   })
   const response1 = await api.get('/number/200')
   t.deepEqual(response1.data, MOCK)

--- a/test/speed.test.js
+++ b/test/speed.test.js
@@ -8,7 +8,7 @@ let port
 let server = null
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port, MOCK)
+  server = await createServer(port, MOCK)
 })
 
 test.after('cleanup', t => {

--- a/test/status.test.js
+++ b/test/status.test.js
@@ -7,7 +7,7 @@ let port
 let server = null
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port)
+  server = await createServer(port)
 })
 
 test.after('cleanup', t => {

--- a/test/timeout.test.js
+++ b/test/timeout.test.js
@@ -7,7 +7,7 @@ let port
 let server = null
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port)
+  server = await createServer(port)
 })
 
 test.after('cleanup', t => {

--- a/test/verbs.test.js
+++ b/test/verbs.test.js
@@ -7,7 +7,7 @@ let port
 let server = null
 test.before(async t => {
   port = await getFreePort()
-  server = createServer(port)
+  server = await createServer(port)
 })
 
 test.after('cleanup', t => {


### PR DESCRIPTION
Thanks to @shellscape for the heads-up on this!

We were getting random failures in our test suite due to the tests not waiting for the server(s) to start before running the tests.

This changes `createServer` to be an async function, which waits for the server to start before initiating the tests.

