### PR TITLE
Fix axios types

### DIFF
--- a/apisauce.d.ts
+++ b/apisauce.d.ts
@@ -93,15 +93,15 @@ export interface ApisauceInstance {
   /** Gets the current base URL used by axios */
   getBaseURL: () => string
 
-  any: <T, U = T>(config: AxiosRequestConfig<T>) => Promise<ApiResponse<T, U>>
-  get: <T, U = T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig<T>) => Promise<ApiResponse<T, U>>
-  delete: <T, U = T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig<T>) => Promise<ApiResponse<T, U>>
-  head: <T, U = T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig<T>) => Promise<ApiResponse<T, U>>
-  post: <T, U = T>(url: string, data?: any, axiosConfig?: AxiosRequestConfig<T>) => Promise<ApiResponse<T, U>>
-  put: <T, U = T>(url: string, data?: any, axiosConfig?: AxiosRequestConfig<T>) => Promise<ApiResponse<T, U>>
-  patch: <T, U = T>(url: string, data?: any, axiosConfig?: AxiosRequestConfig<T>) => Promise<ApiResponse<T, U>>
-  link: <T, U = T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig<T>) => Promise<ApiResponse<T, U>>
-  unlink: <T, U = T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig<T>) => Promise<ApiResponse<T, U>>
+  any: <T, U = T>(config: AxiosRequestConfig) => Promise<ApiResponse<T, U>>
+  get: <T, U = T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T, U>>
+  delete: <T, U = T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T, U>>
+  head: <T, U = T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T, U>>
+  post: <T, U = T>(url: string, data?: any, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T, U>>
+  put: <T, U = T>(url: string, data?: any, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T, U>>
+  patch: <T, U = T>(url: string, data?: any, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T, U>>
+  link: <T, U = T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T, U>>
+  unlink: <T, U = T>(url: string, params?: {}, axiosConfig?: AxiosRequestConfig) => Promise<ApiResponse<T, U>>
 }
 
 export function isCancel(value: any): boolean

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,5 @@
     "strict": false,
     "lib": ["es2015"]
   },
-  "include": [
-    "lib"
-  ]
+  "include": ["lib"]
 }


### PR DESCRIPTION
With the latest update (2.1.4), I'm getting an error:

```
node_modules/apisauce/apisauce.d.ts:96:27 - error TS2315: Type 'AxiosRequestConfig' is not generic.

96   any: <T, U = T>(config: AxiosRequestConfig<T>) => Promise<ApiResponse<T, U>>
                             ~~~~~~~~~~~~~~~~~~~~~
```

This update fixes the AxiosRequestConfig type to remove the generic, which apparently has gone away.