### PR TITLE
fix(deps): upgrade axios and typescript

### DIFF
--- a/lib/apisauce.ts
+++ b/lib/apisauce.ts
@@ -70,6 +70,7 @@ export const CANCEL_ERROR = 'CANCEL_ERROR'
 
 const TIMEOUT_ERROR_CODES = ['ECONNABORTED']
 const NODEJS_CONNECTION_ERROR_CODES = ['ENOTFOUND', 'ECONNREFUSED', 'ECONNRESET']
+const STATUS_ERROR_CODES = ['ERR_BAD_REQUEST', 'ERR_BAD_RESPONSE']
 const in200s = (n: number): boolean => isWithin(200, 299, n)
 const in400s = (n: number): boolean => isWithin(400, 499, n)
 const in500s = (n: number): boolean => isWithin(500, 599, n)
@@ -83,7 +84,7 @@ export const getProblemFromError = error => {
   if (axios.isCancel(error)) return CANCEL_ERROR
 
   // then check the specific error code
-  if (!error.code) return getProblemFromStatus(error.response.status)
+  if (STATUS_ERROR_CODES.includes(error.code)) return getProblemFromStatus(error.response.status)
   if (TIMEOUT_ERROR_CODES.includes(error.code)) return TIMEOUT_ERROR
   if (NODEJS_CONNECTION_ERROR_CODES.includes(error.code)) return CONNECTION_ERROR
   return UNKNOWN_ERROR

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     ]
   },
   "dependencies": {
-    "axios": "^0.21.4"
+    "axios": "^0.26.1"
   },
   "description": "Axios + standardized errors + request/response transforms.",
   "devDependencies": {
@@ -41,7 +41,7 @@
     "tslint": "^5.12.0",
     "tslint-config-prettier": "^1.17.0",
     "tslint-config-standard": "^8.0.1",
-    "typescript": "3.2.1"
+    "typescript": "3.5.1"
   },
   "files": [
     "dist/apisauce.js",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     ]
   },
   "dependencies": {
-    "axios": "^0.26.1"
+    "axios": "^0.27.2"
   },
   "description": "Axios + standardized errors + request/response transforms.",
   "devDependencies": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "es5",
     "module": "es2015",
     "strict": false,
-    "lib": ["es2015"]
+    "lib": ["dom", "es2015"]
   },
   "include": ["lib"]
 }


### PR DESCRIPTION
This fixes vulnerabilities in the axios library: [CVE-2022-0155](https://nvd.nist.gov/vuln/detail/CVE-2022-0155) and [CVE-2022-0536](https://nvd.nist.gov/vuln/detail/CVE-2022-0536).

There are a couple of things to consider if this PR is worth merging:
* There are a [few breaking changes](https://github.com/axios/axios/blob/master/CHANGELOG.md) in axios along the way from 0.21.4 to 0.26.1
* Axios used the [AbortController type](https://github.com/axios/axios/issues/4124) from the DOM library and now doesn't. The upgrade broke a type and the fix was to add "dom" to the tsconfig. Really not sure if that is the correct work around or not.
* The upgrade needed the [Omit utility type](https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys) which wasn't added until 3.5.1, so I had to upgrade the typescript dependency
TBH, I don't understand why the tsconfig doesn't exclude node_modules, so maybe that's the better approach unless I'm missing something.

I tested this locally with my company's iOS and Android app and saw no issues. I did not test on the web.

Fixes: #287 

