### PR TITLE
Fix reading status of undefined

### DIFF
--- a/lib/apisauce.ts
+++ b/lib/apisauce.ts
@@ -83,7 +83,7 @@ export const getProblemFromError = error => {
   if (axios.isCancel(error)) return CANCEL_ERROR
 
   // then check the specific error code
-  if (!error.code) return getProblemFromStatus(error.response.status)
+  if (!error.code) return getProblemFromStatus(error.response?.status)
   if (TIMEOUT_ERROR_CODES.includes(error.code)) return TIMEOUT_ERROR
   if (NODEJS_CONNECTION_ERROR_CODES.includes(error.code)) return CONNECTION_ERROR
   return UNKNOWN_ERROR


### PR DESCRIPTION
I believe this will fix the error: Cannot read properties of undefined (reading 'status') when there is no response (server down).