### PR TITLE
Add testing example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,31 +370,16 @@ Which problem is chosen will be picked by walking down the list.
 
 A common testing pattern is to use `axios-mock-adapter` to mock axios and respond with stubbed data. These libraries mock a specific instance of axios, and don't globally intercept all instances of axios. When using a mocking library like this, it's important to make sure to pass the same axios instance into the mock adapter.
 
-This example will *not* work. `axios-mock-adapter` will not intercept the request and mock the response:
-```javascript
+Here is an example code from axios_mock, modified to work with Apisauce:
+
+```diff
 import apisauce from 'apisauce'
 import MockAdapter from 'axios-mock-adapter'
 
 test('mock adapter', async () => {
   const api = apisauce.create("https://api.github.com")
-  const mock = new MockAdapter(axios)
-  mock.onGet("/repos/skellock/apisauce/commits").reply(200, {
-    commits: [{ id: 1, sha: "aef849923444" }],
-  });
-
-  const response = await api..get('/repos/skellock/apisauce/commits')
-  expect(response.data[0].sha).toEqual"aef849923444")
-})
-```
-
-Instead, create the MockAdapter using the axiosInstance exposed by apisauce. This example will work:
-```javascript
-import apisauce from 'apisauce'
-import MockAdapter from 'axios-mock-adapter'
-
-test('mock adapter', async () => {
-  const api = apisauce.create("https://api.github.com")
-  const mock = new MockAdapter(api.axiosInstance)
+- const mock = new MockAdapter(axios)
++ const mock = new MockAdapter(api.axiosInstance)
   mock.onGet("/repos/skellock/apisauce/commits").reply(200, {
     commits: [{ id: 1, sha: "aef849923444" }],
   });

--- a/README.md
+++ b/README.md
@@ -370,7 +370,6 @@ Which problem is chosen will be picked by walking down the list.
 
 A common testing pattern is to use `axios-mock-adapter` to mock axios and respond with stubbed data. These libraries mock a specific instance of axios, and don't globally intercept all instances of axios. When using a mocking library like this, it's important to make sure to pass the same axios instance into the mock adapter.
 
-
 This example will *not* work. `axios-mock-adapter` will not intercept the request and mock the response:
 ```javascript
 import apisauce from 'apisauce'
@@ -404,8 +403,6 @@ test('mock adapter', async () => {
   expect(response.data[0].sha).toEqual"aef849923444")
 })
 ```
-
-
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -366,6 +366,47 @@ CANCEL_ERROR     'CANCEL_ERROR'     ---           Request has been cancelled. On
 
 Which problem is chosen will be picked by walking down the list.
 
+# Mocking with axios-mock-adapter (or other libraries)
+
+A common testing pattern is to use `axios-mock-adapter` to mock axios and respond with stubbed data. These libraries mock a specific instance of axios, and don't globally intercept all instances of axios. When using a mocking library like this, it's important to make sure to pass the same axios instance into the mock adapter.
+
+
+This example will *not* work. `axios-mock-adapter` will not intercept the request and mock the response:
+```javascript
+import apisauce from 'apisauce'
+import MockAdapter from 'axios-mock-adapter'
+
+test('mock adapter', async () => {
+  const api = apisauce.create("https://api.github.com")
+  const mock = new MockAdapter(axios)
+  mock.onGet("/repos/skellock/apisauce/commits").reply(200, {
+    commits: [{ id: 1, sha: "aef849923444" }],
+  });
+
+  const response = await api..get('/repos/skellock/apisauce/commits')
+  expect(response.data[0].sha).toEqual"aef849923444")
+})
+```
+
+Instead, create the MockAdapter using the axiosInstance exposed by apisauce. This example will work:
+```javascript
+import apisauce from 'apisauce'
+import MockAdapter from 'axios-mock-adapter'
+
+test('mock adapter', async () => {
+  const api = apisauce.create("https://api.github.com")
+  const mock = new MockAdapter(api.axiosInstance)
+  mock.onGet("/repos/skellock/apisauce/commits").reply(200, {
+    commits: [{ id: 1, sha: "aef849923444" }],
+  });
+
+  const response = await api..get('/repos/skellock/apisauce/commits')
+  expect(response.data[0].sha).toEqual"aef849923444")
+})
+```
+
+
+
 # Contributing
 
 Bugs? Comments? Features? PRs and Issues happily welcomed! Make sure to check out our [contributing guide](./github/CONTRIBUTING.md) to get started!


### PR DESCRIPTION
https://github.com/infinitered/apisauce/issues/50 was helpful for me to understand an unexpected issue with testing. Hopefully it'll be helpful to others who have similar issues. 

In my case, we are using axois-mock-adapter for mocking api requests. I think this is an extremely common package and pattern. We upgraded apisauce from 1.21.2 to 1.21.4, and all of the mocks stopped working. 

@skellock's [comment](https://github.com/infinitered/apisauce/issues/50#issuecomment-305764519) helped us to identify the issue, and when we looked through the code we found that 1.21.3 [clones the axios instance](https://github.com/ctimmerm/axios-mock-adapter/blob/v1.21.3/src/index.js#L51) which [was not happening in 1.21.2](https://github.com/ctimmerm/axios-mock-adapter/blob/v1.21.2/src/index.js#L48). I wasn't able to find anything in release notes about that, and we didn't expect this to change in a minor/patch release
