### PR TITLE
fix: Upgrades axios to 1.4.0 and fixes Node v17+ ipv6 issue in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@
 defaults: &defaults
   docker:
     # Choose the version of Node you want here
-    - image: circleci/node:10.11
+    - image: cimg/node:19.9
   working_directory: ~/repo
 
 version: 2
@@ -29,7 +29,6 @@ jobs:
           paths:
             - node_modules
           key: v1-dependencies-{{ checksum "package.json" }}
-
 
   rollup_and_tests:
     <<: *defaults

--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
     ]
   },
   "dependencies": {
-    "axios": "^0.27.2"
+    "axios": "^1.4.0"
   },
   "description": "Axios + standardized errors + request/response transforms.",
   "devDependencies": {
     "@semantic-release/git": "^7.0.5",
     "@types/node": "14.0.4",
     "@types/ramda": "^0.25.28",
-    "ava": "^0.25.0",
+    "ava": "0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-eslint": "^8.2.3",
@@ -38,10 +38,10 @@
     "rollup-plugin-node-resolve": "^3.2.0",
     "rollup-plugin-uglify": "^3.0.0",
     "semantic-release": "^15.12.4",
-    "tslint": "^5.12.0",
+    "tslint": "^6.1.3",
     "tslint-config-prettier": "^1.17.0",
-    "tslint-config-standard": "^8.0.1",
-    "typescript": "3.5.1"
+    "tslint-config-standard": "^9.0.0",
+    "typescript": "5.1.3"
   },
   "files": [
     "dist/apisauce.js",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@semantic-release/git": "^7.0.5",
     "@types/node": "14.0.4",
     "@types/ramda": "^0.25.28",
-    "ava": "0",
+    "ava": "0.25.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-eslint": "^8.2.3",

--- a/test/_server.js
+++ b/test/_server.js
@@ -61,6 +61,6 @@ export default (port, mockData = {}) => {
         })
       }
     })
-    server.listen(port, 'localhost', () => resolve(server))
+    server.listen(port, '::', () => resolve(server))
   })
 }


### PR DESCRIPTION
Fixes #307 (axios was not fully upgraded on 3.0.0 as planned).

Also fixed an issue when using nodejs v17+ as the http.createServer function uses ipv6 by default and didn't listen on 127.0.0.1 as previous nodes did.

Note: while this is technically a breaking change, the break was supposed to happen in 3.0.0, so we will release this as 3.0.1 and deprecate 3.0.0.