### PR TITLE
Removed ramda and ramdasauce from tests using GPT-4

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   "devDependencies": {
     "@semantic-release/git": "^7.0.5",
     "@types/node": "14.0.4",
-    "@types/ramda": "^0.25.28",
     "ava": "0.25.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
@@ -29,8 +28,6 @@
     "npm-run-all": "^4.1.5",
     "nyc": "^11.8.0",
     "prettier": "^1.15.3",
-    "ramda": "^0.25.0",
-    "ramdasauce": "^2.1.0",
     "rollup": "^0.59.1",
     "rollup-plugin-babel": "^3.0.4",
     "rollup-plugin-commonjs": "^8.4.1",

--- a/test/_server.js
+++ b/test/_server.js
@@ -1,6 +1,5 @@
+
 import http from 'http'
-import R from 'ramda'
-import RS from 'ramdasauce'
 
 const processPost = (request, response, callback) => {
   let queryData = ''
@@ -35,20 +34,20 @@ export default (port, mockData = {}) => {
         return
       }
 
-      if (RS.startsWith('/echo', url)) {
-        const echo = R.slice(8, Infinity, url)
+      if (url.startsWith('/echo')) {
+        const echo = url.slice(8)
         sendResponse(res, 200, JSON.stringify({ echo }))
         return
       }
 
-      if (RS.startsWith('/number', url)) {
-        const n = R.slice(8, 11, url)
+      if (url.startsWith('/number')) {
+        const n = url.slice(8, 11)
         sendResponse(res, n, JSON.stringify(mockData))
         return
       }
 
-      if (RS.startsWith('/sleep', url)) {
-        const wait = R.pipe(R.split('/'), R.last, Number)(url)
+      if (url.startsWith('/sleep')) {
+        const wait = Number(url.split('/').pop())
         setTimeout(() => {
           send200(res)
         }, wait)

--- a/test/async-request-transform.test.js
+++ b/test/async-request-transform.test.js
@@ -1,6 +1,5 @@
 import test from 'ava'
 import { create } from '../lib/apisauce'
-import R from 'ramda'
 import createServer from './_server'
 import getFreePort from './_getFreePort'
 
@@ -33,7 +32,7 @@ test('attaches an async request transform', t => {
   t.truthy(api.addAsyncRequestTransform)
   t.truthy(api.asyncRequestTransforms)
   t.is(api.asyncRequestTransforms.length, 0)
-  api.addAsyncRequestTransform(R.identity)
+  api.addAsyncRequestTransform(request => request) // Replaced R.identity with plain JS function
   t.is(api.asyncRequestTransforms.length, 1)
 })
 
@@ -145,7 +144,7 @@ test('url can be changed', t => {
   x.addAsyncRequestTransform(req => {
     return new Promise((resolve, reject) => {
       setImmediate(_ => {
-        req.url = R.replace('/201', '/200', req.url)
+        req.url = req.url.replace('/201', '/200') // Replaced R.replace with plain JS function
         resolve()
       })
     })

--- a/test/async-request-transform.test.js
+++ b/test/async-request-transform.test.js
@@ -32,7 +32,7 @@ test('attaches an async request transform', t => {
   t.truthy(api.addAsyncRequestTransform)
   t.truthy(api.asyncRequestTransforms)
   t.is(api.asyncRequestTransforms.length, 0)
-  api.addAsyncRequestTransform(request => request) // Replaced R.identity with plain JS function
+  api.addAsyncRequestTransform(request => request)
   t.is(api.asyncRequestTransforms.length, 1)
 })
 
@@ -144,7 +144,7 @@ test('url can be changed', t => {
   x.addAsyncRequestTransform(req => {
     return new Promise((resolve, reject) => {
       setImmediate(_ => {
-        req.url = req.url.replace('/201', '/200') // Replaced R.replace with plain JS function
+        req.url = req.url.replace('/201', '/200')
         resolve()
       })
     })

--- a/test/async-response-transform.test.js
+++ b/test/async-response-transform.test.js
@@ -22,7 +22,7 @@ test('attaches a async response transform', t => {
   t.truthy(api.addAsyncResponseTransform)
   t.truthy(api.asyncResponseTransforms)
   t.is(api.asyncResponseTransforms.length, 0)
-  api.addAsyncResponseTransform(data => data) // Replaced R.identity with a plain JS function
+  api.addAsyncResponseTransform(data => data)
   t.is(api.asyncResponseTransforms.length, 1)
 })
 
@@ -54,7 +54,7 @@ test('swap out data on response', t => {
       setImmediate(_ => {
         count++
         response.status = 222
-        response.data = { a: response.data.a.b.reverse() } // Replaced R.reverse with Array.prototype.reverse
+        response.data = { a: response.data.a.b.reverse() }
         resolve(response)
       })
     })

--- a/test/async-response-transform.test.js
+++ b/test/async-response-transform.test.js
@@ -1,6 +1,5 @@
 import test from 'ava'
 import { create } from '../lib/apisauce'
-import R from 'ramda'
 import createServer from './_server'
 import getFreePort from './_getFreePort'
 
@@ -23,7 +22,7 @@ test('attaches a async response transform', t => {
   t.truthy(api.addAsyncResponseTransform)
   t.truthy(api.asyncResponseTransforms)
   t.is(api.asyncResponseTransforms.length, 0)
-  api.addAsyncResponseTransform(R.identity)
+  api.addAsyncResponseTransform(data => data) // Replaced R.identity with a plain JS function
   t.is(api.asyncResponseTransforms.length, 1)
 })
 
@@ -55,7 +54,7 @@ test('swap out data on response', t => {
       setImmediate(_ => {
         count++
         response.status = 222
-        response.data = { a: R.reverse(response.data.a.b) }
+        response.data = { a: response.data.a.b.reverse() } // Replaced R.reverse with Array.prototype.reverse
         resolve(response)
       })
     })

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,11 +1,10 @@
 import test from 'ava'
 import { create, DEFAULT_HEADERS } from '../lib/apisauce'
-import { merge } from 'ramda'
 import axios from 'axios'
 
 const validConfig = {
   baseURL: 'http://localhost:9991',
-  headers: { 'X-Testing': 'hello' }
+  headers: { 'X-Testing': 'hello' },
 }
 
 test('is a function', t => {
@@ -23,7 +22,7 @@ test('configures axios correctly', t => {
   const { axiosInstance } = apisauce
   t.is(axiosInstance.defaults.timeout, 0)
   t.is(axiosInstance.defaults.baseURL, validConfig.baseURL)
-  t.deepEqual(apisauce.headers, merge(DEFAULT_HEADERS, validConfig.headers))
+  t.deepEqual(apisauce.headers, Object.assign({}, DEFAULT_HEADERS, validConfig.headers))
 })
 
 test('configures axios correctly with passed instance', t => {
@@ -32,6 +31,5 @@ test('configures axios correctly with passed instance', t => {
   const { axiosInstance } = apisauce
   t.is(axiosInstance.defaults.timeout, 0)
   t.is(axiosInstance.defaults.baseURL, validConfig.baseURL)
-  t.deepEqual(apisauce.headers, merge(DEFAULT_HEADERS, validConfig.headers))
+  t.deepEqual(apisauce.headers, Object.assign({}, DEFAULT_HEADERS, validConfig.headers))
 })
-

--- a/test/monitor.test.js
+++ b/test/monitor.test.js
@@ -1,6 +1,5 @@
 import test from 'ava'
 import { create } from '../lib/apisauce'
-import R from 'ramda'
 import createServer from './_server'
 import getFreePort from './_getFreePort'
 
@@ -21,7 +20,7 @@ test('attaches a monitor', t => {
   t.truthy(api.addMonitor)
   t.truthy(api.monitors)
   t.is(api.monitors.length, 0)
-  api.addMonitor(R.identity)
+  api.addMonitor(x => x)
   t.is(api.monitors.length, 1)
 })
 

--- a/test/request-transform.test.js
+++ b/test/request-transform.test.js
@@ -1,6 +1,5 @@
 import test from 'ava'
 import { create } from '../lib/apisauce'
-import R from 'ramda'
 import createServer from './_server'
 import getFreePort from './_getFreePort'
 
@@ -21,7 +20,7 @@ test('attaches a request transform', t => {
   t.truthy(api.addRequestTransform)
   t.truthy(api.requestTransforms)
   t.is(api.requestTransforms.length, 0)
-  api.addRequestTransform(R.identity)
+  api.addRequestTransform(request => request)
   t.is(api.requestTransforms.length, 1)
 })
 
@@ -70,7 +69,7 @@ test('fires for gets', t => {
 test('url can be changed', t => {
   const x = create({ baseURL: `http://localhost:${port}` })
   x.addRequestTransform(request => {
-    request.url = R.replace('/201', '/200', request.url)
+    request.url = request.url.replace('/201', '/200')
   })
   return x.get('/number/201', { x: 1 }).then(response => {
     t.is(response.status, 200)

--- a/test/response-transform.test.js
+++ b/test/response-transform.test.js
@@ -1,6 +1,5 @@
 import test from 'ava'
 import { create } from '../lib/apisauce'
-import R from 'ramda'
 import createServer from './_server'
 import getFreePort from './_getFreePort'
 
@@ -21,7 +20,7 @@ test('attaches a response transform', t => {
   t.truthy(api.addResponseTransform)
   t.truthy(api.responseTransforms)
   t.is(api.responseTransforms.length, 0)
-  api.addResponseTransform(R.identity)
+  api.addResponseTransform(response => response)
   t.is(api.responseTransforms.length, 1)
 })
 
@@ -46,7 +45,7 @@ test('swap out data on response', t => {
   x.addResponseTransform(response => {
     count++
     response.status = 222
-    response.data = { a: R.reverse(response.data.a.b) }
+    response.data = { a: response.data.a.b.reverse() }
   })
   // t.is(count, 0)
   return x.get('/number/201').then(response => {


### PR DESCRIPTION
Using an internal tool ("flame"), I replaced ramda and ramdasauce with vanilla javascript equivalents.