### PR TITLE
fix(minor): use axios as peer dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ yarn.lock
 dist
 .vscode
 lib/apisauce.js
+.idea

--- a/package.json
+++ b/package.json
@@ -10,11 +10,12 @@
       "babel-core/register"
     ]
   },
-  "dependencies": {
-    "axios": "^1.4.0"
+  "peerDependencies": {
+    "axios": "^1.6.0"
   },
   "description": "Axios + standardized errors + request/response transforms.",
   "devDependencies": {
+    "@types/axios": "^0.14.0",
     "@semantic-release/git": "^7.0.5",
     "@types/node": "14.0.4",
     "ava": "0.25.0",


### PR DESCRIPTION
Use `axios` as `peerDependencies` from version `1.6.X` to prevent some not assignable types