### PR TITLE
Fix nullish coaleshing on axios response conversion

### DIFF
--- a/lib/apisauce.ts
+++ b/lib/apisauce.ts
@@ -261,7 +261,7 @@ export const create = config => {
     const ok = in200s(status)
     const config = axiosResult.config || null
     const headers = (response && response.headers) || null
-    let data = (response && response.data) || null
+    let data = (response && response.data) ?? null
 
     // give an opportunity for anything to the response transforms to change stuff along the way
     let transformedResponse = {

--- a/test/_server.js
+++ b/test/_server.js
@@ -46,6 +46,11 @@ export default (port, mockData = {}) => {
         return
       }
 
+      if (url.startsWith('/falsy')) {
+        sendResponse(res, 200, JSON.stringify(false))
+        return
+      }
+
       if (url.startsWith('/sleep')) {
         const wait = Number(url.split('/').pop())
         setTimeout(() => {

--- a/test/data.test.js
+++ b/test/data.test.js
@@ -42,7 +42,6 @@ test('has valid data with a 500s', t => {
 test('Falsy data is preserved', t => {
   const x = create({ baseURL: `http://localhost:${port}` })
   return x.get('/falsy').then(response => {
-    t.is(response.status, 200)
     t.is(response.data, false)
   })
 })

--- a/test/data.test.js
+++ b/test/data.test.js
@@ -38,3 +38,11 @@ test('has valid data with a 500s', t => {
     t.deepEqual(response.data, MOCK)
   })
 })
+
+test('Falsy data is preserved', t => {
+  const x = create({ baseURL: `http://localhost:${port}` })
+  return x.get('/falsy').then(response => {
+    t.is(response.status, 200)
+    t.is(response.data, false)
+  })
+})


### PR DESCRIPTION
## TLDR
The use of a logical OR when converting the response incorrectly assigns `null` if the body is a falsy value and has been replaced with a `??`

## The Issue
I observed that if the response body is `false` or any other falsy value, the data inside the response object is `null`. If instead the body is `true`, the data object is correctly `true`.

When converting the axios response, the use of the logical OR shortcuts falsy values to be `null`. 
The OR in question has been swapped with a nullish coaleshing operator to only shortcut on null values.

I also added a test case for this exact scenario, let me know if that is unwanted
