### PR TITLE
Bump axios to 1.11.0 to resolve snyk security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     ]
   },
   "dependencies": {
-    "axios": "^1.10.0"
+    "axios": "^1.11.0"
   },
   "description": "Axios + standardized errors + request/response transforms.",
   "devDependencies": {


### PR DESCRIPTION
This PR addresses a critical vulnerability reported by Snyk in the form-data package, which is a transitive dependency of axios@1.10.0.

Vulnerability: [Predictable Value Range from Previous Values (CVE-2025-7783)](https://security.snyk.io/vuln/SNYK-JS-FORMDATA-10841150)
Severity: Critical (CVSS 9.4)
Introduced via: axios@1.10.0 > form-data@4.0.0
Remediation: Upgrade form-data to 4.0.4 or higher.

This vulnerability stems from form-data's use of Math.random() for HTTP multipart boundary generation, which allows for predictability and potential exploitation via parameter pollution attacks.

Axios PR addressing the fix: https://github.com/axios/axios/pull/6970